### PR TITLE
improv: remove id from keyvalueentries objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ async function listEntriesKvms(kvm) {
     );
     return response.data.keyValueEntries
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((e) => ({ ...e, id: e.name }));
+      .map((e) => ({ ...e }));
   } catch (error) {
     console.error(error);
     return [];


### PR DESCRIPTION
## Description
During the use of the array export functionality with the key-value entries map, an extraneous property (**id**) was detected that does not belong to the object. 
This PR removes the unnecessary property and ensures the object is properly structured.